### PR TITLE
test SQSが接続できるまではテスト用のデータを返却するようにする

### DIFF
--- a/benchmarker/cli.go
+++ b/benchmarker/cli.go
@@ -100,8 +100,13 @@ func (cli *CLI) Run(args []string) int {
 	config, err := runningConfig.GetRunningConfig()
 	if err != nil {
 		fmt.Fprintf(cli.errStream, "Failed to get running config: %s\n", err)
-		return ExitCodeError
+		log.Println("Failed to get running config use Sample ip and teamID")
+		config = runningconfig.RunningConfig{
+			TargetAddress: "http://54.249.115.183",
+			TeamID:        1,
+		}
 	}
+
 	target = config.TargetAddress
 
 	// Define option flag parse


### PR DESCRIPTION
動作確認テストをできるようにしておくため、SQSからデータを取得する部分はエラーログを吐いた後デフォルトの値を使用するようにしておく。

SQS立ち上げ+lambdaから起動できるようになった後直す