### PR TITLE
tmp_imgディレクトリを使う

### DIFF
--- a/benchmarker/README.md
+++ b/benchmarker/README.md
@@ -4,8 +4,8 @@
 以下のコマンドでimageをデプロイできる。--profileはローカルの環境にてecrにpushできる権限を持ったものを指定してください。
 
 ```bash
-aws ecr get-login-password --region ap-northeast-1 --profile cto-a | docker login --username AWS --password-stdin 254374927794.dkr.ecr.ap-northeast-1.amazonaws.com
+aws ecr get-login-password --region ap-northeast-1 --profile cto-a | docker login --username AWS --password-stdin 009160051284.dkr.ecr.ap-northeast-1.amazonaws.com
 docker build -t private-isu-benchmarker-repository .
-docker tag private-isu-benchmarker-repository:latest 254374927794.dkr.ecr.ap-northeast-1.amazonaws.com/private-isu-benchmarker-repository:latest
-docker push 254374927794.dkr.ecr.ap-northeast-1.amazonaws.com/private-isu-benchmarker-repository:latest
+docker tag private-isu-benchmarker-repository:latest 009160051284.dkr.ecr.ap-northeast-1.amazonaws.com/private-isu-benchmarker-repository:latest
+docker push 009160051284.dkr.ecr.ap-northeast-1.amazonaws.com/private-isu-benchmarker-repository:latest
 ```

--- a/benchmarker/userdata.go
+++ b/benchmarker/userdata.go
@@ -60,7 +60,7 @@ func prepareUserdata(userdata string) ([]user, []user, []user, []string, []*chec
 		sentences = append(sentences, sentence)
 	}
 
-	imgs, err := filepath.Glob(userdata + "/img/000*") // 00001.jpg, 00002.png, 00003.gif など
+	imgs, err := filepath.Glob(userdata + "/tmp_img/000*") // 00001.jpg, 00002.png, 00003.gif など
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
`userdata/img`ディレクトリには何も画像はないためベンチマーカーの実行時にエラーになる。

https://github.com/cto-a/private-isu-ops/pull/20/files あたりでtmp_img/ディレクトリが発生している。本来ならベンチマーカーのマシンイメージに入っている大量の画像を使うのだろう。
しかしそれをコンテナイメージに組み込もうとすると大変なことになる。なので数枚の画像のみをtmp_img/に入れてそれを使う...みたいな感じが意図されていたのだろうか？