### PR TITLE
add retryStrategy

### DIFF
--- a/benchmarker/terraform/container_definitions.json
+++ b/benchmarker/terraform/container_definitions.json
@@ -33,6 +33,13 @@
                 "name": "APP_SYNC_API_KEY",
                 "valueFrom": "arn:aws:ssm:ap-northeast-1:009160051284:parameter/APP_SYNC_API_KEY"
             }
-        ]
+        ],
+        "retryStrategy": {
+            "attempts": 3,
+            "interval": 30,
+            "statusCodes": [
+                2
+            ]
+        }
     }
 ]


### PR DESCRIPTION
benchmarker-container が異常終了（ステータスコード 2）した場合、30秒間隔で最大3回リトライが試みられます。
https://github.com/cto-a/private-isu-ops/issues/70 が「終了コード: 2」なので救えるかも

<img width="1388" alt="image" src="https://github.com/user-attachments/assets/ae070dcd-a9df-43de-8507-f9535c16275c">
